### PR TITLE
Up for discussion: made Config and ProfileWrapper more accessible

### DIFF
--- a/src/main/java/org/pac4j/undertow/Config.java
+++ b/src/main/java/org/pac4j/undertow/Config.java
@@ -44,6 +44,13 @@ public final class Config {
 
     private final SessionConfig sessionCookieConfig = new SessionCookieConfig();
 
+    public Config() {
+    }
+
+    public Config(Clients clients) {
+        this.clients = clients;
+    }
+    
     public String getDefaultSuccessUrl() {
         return defaultSuccessUrl;
     }

--- a/src/main/java/org/pac4j/undertow/ProfileWrapper.java
+++ b/src/main/java/org/pac4j/undertow/ProfileWrapper.java
@@ -46,11 +46,11 @@ public class ProfileWrapper implements Serializable {
         this.account = new ClientAccount(profile);
     }
 
-    CommonProfile getProfile() {
+    public CommonProfile getProfile() {
         return this.profile;
     }
 
-    Account getAccount() {
+    public Account getAccount() {
         return this.account;
     }
 


### PR DESCRIPTION
made Config object instantiable with clients in constructor.
made ProfileWrapper methods public for ease of use: the undertow-pac4j demo wouldn't work if it wouldn't be in the same namespace I think... but my java is a bit rusty... :/