### PR TITLE
Basic fix for #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ public class DemoConfigFactory implements ConfigFactory {
         final FormClient formClient = new FormClient("http://localhost:8080/loginForm.html", new SimpleTestUsernamePasswordAuthenticator());
         final IndirectBasicAuthClient indirectBasicAuthClient = new IndirectBasicAuthClient(new SimpleTestUsernamePasswordAuthenticator());
 
-        final CasClient casClient = new CasClient("https://casserverpac4j.herokuapp.com/login");
+        final CasConfiguration casConfiguration = new CasConfiguration("https://casserverpac4j.herokuapp.com/login");
+        final CasClient casClient = new CasClient(casConfiguration);
 
         ParameterClient parameterClient = new ParameterClient("token", new JwtAuthenticator(DemoServer.JWT_SALT));
         parameterClient.setSupportGetRequest(true);

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ It must be built via a configuration factory (`org.pac4j.core.config.ConfigFacto
 public class DemoConfigFactory implements ConfigFactory {
 
     public Config build() {
-        final OidcClient oidcClient = new OidcClient();
-        oidcClient.setClientID(clientId);
-        oidcClient.setSecret(secret);
-        oidcClient.setDiscoveryURI("https://accounts.google.com/.well-known/openid-configuration");
-        oidcClient.setAuthorizationGenerator(profile -> profile.addRole("ROLE_ADMIN"));
+        final OidcConfiguration oidcConfiguration = new OidcConfiguration();
+        oidcConfiguration.setClientId(clientId);
+        oidcConfiguration.setSecret(secret);
+        oidcConfiguration.setDiscoveryURI("https://accounts.google.com/.well-known/openid-configuration");
+        final OidcClient<OidcProfile> oidcClient = new OidcClient<>(oidcConfiguration);
+        oidcClient.setAuthorizationGenerator((context, profile) -> {profile.addRole("ROLE_ADMIN"); return profile;});
 
         final SAML2ClientConfiguration cfg = new SAML2ClientConfiguration("resource:samlKeystore.jks", "pac4j-demo-passwd", "pac4j-demo-passwd", "resource:metadata-okta.xml");
         cfg.setMaximumAuthenticationLifetime(3600);
@@ -208,6 +209,12 @@ The following parameters are available:
 
 2) `logoutUrlPattern` (optional): the logout url pattern that the `url` parameter must match (only relative urls are allowed by default).
 
+3) `localLogout` (optional): remove pac4j profiles from web session (default: true)
+
+4) `destroySession` (optional): destroy web session on logout / tell browser to delete session cookie (default: false)
+
+5) `centralLogout` (optional): redirect user to identity provider for central logout (default: false)
+
 Example:
 
 ```java
@@ -216,6 +223,14 @@ path.addExactPath("/logout", new ApplicationLogoutHandler(config, "/?defaulturla
 
 
 ## Migration guide
+
+### 1.2 -> 2.0
+
+Version 2 of pac4j-core 2 is now required.
+
+The methods `getApplicationLogoutLogic` and `setApplicationLogoutLogic` of `ApplicationLogoutHandler` are renamed to `getLogoutLogic` and `setLogoutLogic` to better reflect the new type introduced in pac4j 2.
+
+`ApplicationLogoutHandler` gained getters and setter for the new settings `localLogout` (remove pac4j profiles from web session), `destroySession` (destroy web session on logout) and `centralLogout` (redirect user to identity provider for central logout).
 
 ### 1.1 -> 1.2
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
     </scm>
 
     <properties>
-        <pac4j.version>1.9.4</pac4j.version>
-        <undertow.version>1.3.23.Final</undertow.version>
+        <pac4j.version>2.2.1</pac4j.version>
+        <undertow.version>1.4.22.Final</undertow.version>
         <java.version>1.8</java.version>
     </properties>
 

--- a/src/main/java/org/pac4j/undertow/context/UndertowWebContext.java
+++ b/src/main/java/org/pac4j/undertow/context/UndertowWebContext.java
@@ -48,8 +48,15 @@ public class UndertowWebContext implements WebContext {
         return exchange;
     }
 
+    @Override
     public SessionStore<UndertowWebContext> getSessionStore() {
         return sessionStore;
+    }
+    
+    @Override
+    @Deprecated
+    public void setSessionStore(SessionStore sessionStore) {
+        throw new UnsupportedOperationException("not supported");
     }
 
     @Override
@@ -81,42 +88,32 @@ public class UndertowWebContext implements WebContext {
         }
         return map;
     }
-
+    
     @Override
     public String getRequestHeader(final String name) {
         return exchange.getRequestHeaders().get(name, 0);
     }
-
-    @Override
-    public void setSessionAttribute(final String name, final Object value) {
-        sessionStore.set(this, name, value);
-    }
-
-    @Override
-    public Object getSessionAttribute(final String name) {
-        return sessionStore.get(this, name);
-    }
-
+    
     @Override
     public String getRequestMethod() {
         return exchange.getRequestMethod().toString();
     }
-
+    
     @Override
     public void writeResponseContent(final String content) {
         exchange.getResponseSender().send(content);
     }
-
+    
     @Override
     public void setResponseStatus(final int code) {
         exchange.setResponseCode(code);
     }
-
+    
     @Override
     public void setResponseHeader(final String name, final String value) {
         exchange.getResponseHeaders().put(HttpString.tryFromString(name), value);
     }
-
+    
     @Override
     public String getServerName() {
         return exchange.getHostName();
@@ -140,12 +137,12 @@ public class UndertowWebContext implements WebContext {
         }
         return full;
     }
-
+    
     @Override
     public String getRemoteAddr() {
         return exchange.getSourceAddress().getAddress().getHostAddress();
     }
-
+    
     @Override
     public void addResponseCookie(final Cookie cookie) {
         final CookieImpl newCookie = new CookieImpl(cookie.getName(), cookie.getValue());
@@ -157,7 +154,7 @@ public class UndertowWebContext implements WebContext {
         newCookie.setHttpOnly(cookie.isHttpOnly());
         exchange.setResponseCookie(newCookie);
     }
-
+    
     @Override
     public void setRequestAttribute(final String name, final Object value) {
         String result = null;
@@ -172,12 +169,12 @@ public class UndertowWebContext implements WebContext {
     public String getPath() {
         return exchange.getRequestPath();
     }
-
+    
     @Override
     public void setResponseContentType(final String content) {
         exchange.getResponseHeaders().add(HttpString.tryFromString(HttpConstants.CONTENT_TYPE_HEADER), content);
     }
-
+    
     @Override
     public Collection<Cookie> getRequestCookies() {
         Map<String, io.undertow.server.handlers.Cookie> cookiesMap = exchange.getRequestCookies();
@@ -195,12 +192,7 @@ public class UndertowWebContext implements WebContext {
         }
         return cookies;
     }
-
-    @Override
-    public Object getSessionIdentifier() {
-        return sessionStore.getOrCreateSessionId(this);
-    }
-
+    
     @Override
     public Object getRequestAttribute(final String name) {
         Object value = null;
@@ -214,7 +206,7 @@ public class UndertowWebContext implements WebContext {
         }
         return value;
     }
-
+    
     @Override
     public boolean isSecure() {
         return "HTTPS".equalsIgnoreCase(getScheme());

--- a/src/main/java/org/pac4j/undertow/context/UndertowWebContext.java
+++ b/src/main/java/org/pac4j/undertow/context/UndertowWebContext.java
@@ -52,7 +52,7 @@ public class UndertowWebContext implements WebContext {
     public SessionStore<UndertowWebContext> getSessionStore() {
         return sessionStore;
     }
-    
+
     @Override
     @Deprecated
     public void setSessionStore(SessionStore sessionStore) {
@@ -88,32 +88,32 @@ public class UndertowWebContext implements WebContext {
         }
         return map;
     }
-    
+
     @Override
     public String getRequestHeader(final String name) {
         return exchange.getRequestHeaders().get(name, 0);
     }
-    
+
     @Override
     public String getRequestMethod() {
         return exchange.getRequestMethod().toString();
     }
-    
+
     @Override
     public void writeResponseContent(final String content) {
         exchange.getResponseSender().send(content);
     }
-    
+
     @Override
     public void setResponseStatus(final int code) {
         exchange.setStatusCode(code);
     }
-    
+
     @Override
     public void setResponseHeader(final String name, final String value) {
         exchange.getResponseHeaders().put(HttpString.tryFromString(name), value);
     }
-    
+
     @Override
     public String getServerName() {
         return exchange.getHostName();
@@ -137,12 +137,12 @@ public class UndertowWebContext implements WebContext {
         }
         return full;
     }
-    
+
     @Override
     public String getRemoteAddr() {
         return exchange.getSourceAddress().getAddress().getHostAddress();
     }
-    
+
     @Override
     public void addResponseCookie(final Cookie cookie) {
         final CookieImpl newCookie = new CookieImpl(cookie.getName(), cookie.getValue());
@@ -154,7 +154,7 @@ public class UndertowWebContext implements WebContext {
         newCookie.setHttpOnly(cookie.isHttpOnly());
         exchange.setResponseCookie(newCookie);
     }
-    
+
     @Override
     public void setRequestAttribute(final String name, final Object value) {
         String result = null;
@@ -169,12 +169,12 @@ public class UndertowWebContext implements WebContext {
     public String getPath() {
         return exchange.getRequestPath();
     }
-    
+
     @Override
     public void setResponseContentType(final String content) {
         exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, content);
     }
-    
+
     @Override
     public Collection<Cookie> getRequestCookies() {
         final Collection<io.undertow.server.handlers.Cookie> uCookies = exchange.getRequestCookies().values();
@@ -191,7 +191,7 @@ public class UndertowWebContext implements WebContext {
         }
         return cookies;
     }
-    
+
     @Override
     public Object getRequestAttribute(final String name) {
         Object value = null;
@@ -205,7 +205,7 @@ public class UndertowWebContext implements WebContext {
         }
         return value;
     }
-    
+
     @Override
     public boolean isSecure() {
         return exchange.isSecure();

--- a/src/main/java/org/pac4j/undertow/context/UndertowWebContext.java
+++ b/src/main/java/org/pac4j/undertow/context/UndertowWebContext.java
@@ -4,6 +4,7 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.CookieImpl;
 import io.undertow.server.handlers.form.FormData;
 import io.undertow.server.handlers.form.FormDataParser;
+import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
 
 import java.io.Serializable;
@@ -11,7 +12,6 @@ import java.util.*;
 import java.util.Map.Entry;
 
 import org.pac4j.core.context.Cookie;
-import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.util.CommonHelper;
@@ -106,7 +106,7 @@ public class UndertowWebContext implements WebContext {
     
     @Override
     public void setResponseStatus(final int code) {
-        exchange.setResponseCode(code);
+        exchange.setStatusCode(code);
     }
     
     @Override
@@ -172,15 +172,14 @@ public class UndertowWebContext implements WebContext {
     
     @Override
     public void setResponseContentType(final String content) {
-        exchange.getResponseHeaders().add(HttpString.tryFromString(HttpConstants.CONTENT_TYPE_HEADER), content);
+        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, content);
     }
     
     @Override
     public Collection<Cookie> getRequestCookies() {
-        Map<String, io.undertow.server.handlers.Cookie> cookiesMap = exchange.getRequestCookies();
-        final List<Cookie> cookies = new ArrayList<>();
-        for (final Entry<String, io.undertow.server.handlers.Cookie> entry : cookiesMap.entrySet()) {
-            final io.undertow.server.handlers.Cookie uCookie = entry.getValue();
+        final Collection<io.undertow.server.handlers.Cookie> uCookies = exchange.getRequestCookies().values();
+        final List<Cookie> cookies = new ArrayList<>(uCookies.size());
+        for (final io.undertow.server.handlers.Cookie uCookie : uCookies) {
             final Cookie cookie = new Cookie(uCookie.getName(), uCookie.getValue());
             cookie.setComment(uCookie.getComment());
             cookie.setDomain(uCookie.getDomain());
@@ -209,6 +208,6 @@ public class UndertowWebContext implements WebContext {
     
     @Override
     public boolean isSecure() {
-        return "HTTPS".equalsIgnoreCase(getScheme());
+        return exchange.isSecure();
     }
 }

--- a/src/main/java/org/pac4j/undertow/handler/ApplicationLogoutHandler.java
+++ b/src/main/java/org/pac4j/undertow/handler/ApplicationLogoutHandler.java
@@ -62,7 +62,7 @@ public class ApplicationLogoutHandler implements HttpHandler {
     @Override
     public void handleRequest(final HttpServerExchange exchange) throws Exception {
 
-        assertNotNull("applicationLogoutLogic", logoutLogic);
+        assertNotNull("logoutLogic", logoutLogic);
         assertNotNull("config", config);
         final UndertowWebContext context = new UndertowWebContext(exchange, config.getSessionStore());
 


### PR DESCRIPTION
Breaking changes:
- pac4j 2 removed `(Default)ApplicationLogoutLogic` and introduced `(Default)LogoutLogic`. Those were used in the public API, so methods like `ApplicationLogoutHandler::setApplicationLogoutLogic` would break anyway, so I renamed them to at least match the new naming scheme: `ApplicationLogoutHandler::setLogoutLogic`.

I'm not very confident about `getTrackableSession` and `buildFromTrackableSession` in `UndertowSessionStore`, how are those used? What methods will be called on the SessionStore after buildFromTrackableSession is called?

@leleuj 
While looking at the code, I made a list of changes I'd like to see before a 2.0 release:
- Make `ApplicationLogoutHandler`, `CallbackHandler` and `SecurityHandler` immutable. These can't be reliably modified (without locking) while the server is running anyway. This would also move some potential errors (required fields not set etc.) into constructors, to they will happen as soon as possible.
- Intruduce some Builders for those handlers. Especially ApplicationLogoutHandler got many attributes and a constructor taking 6 arguments with three booleans is hard to read / get wrong.

Would you be open for one or more PRs for those?