### PR TITLE
Fix #50: using Undertow attachments for WebContext request attributes

### DIFF
--- a/src/main/java/org/pac4j/undertow/context/RequestAttributesMap.java
+++ b/src/main/java/org/pac4j/undertow/context/RequestAttributesMap.java
@@ -6,11 +6,14 @@ import io.undertow.util.AttachmentKey;
 import java.util.HashMap;
 
 /**
- * A map of request attributed stored in Undertow's HttpServerExchange as an attachment.
+ * A map of request attributes stored in Undertow's HttpServerExchange as an attachment.
  *
  * This is a simple extension of a HashMap that adds no custom logic, but it must be
  * a separate class, because Undertow uses class-based AttachmentKey to distinguish
  * attachment types.
+ *
+ * @author Igor Lobanov
+ * @since 4.1.0
  */
 public class RequestAttributesMap extends HashMap<String, Object> {
 

--- a/src/main/java/org/pac4j/undertow/context/RequestAttributesMap.java
+++ b/src/main/java/org/pac4j/undertow/context/RequestAttributesMap.java
@@ -1,0 +1,33 @@
+package org.pac4j.undertow.context;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.AttachmentKey;
+
+import java.util.HashMap;
+
+/**
+ * A map of request attributed stored in Undertow's HttpServerExchange as an attachment.
+ *
+ * This is a simple extension of a HashMap that adds no custom logic, but it must be
+ * a separate class, because Undertow uses class-based AttachmentKey to distinguish
+ * attachment types.
+ */
+public class RequestAttributesMap extends HashMap<String, Object> {
+
+    /** Actual singleton attachment key instance */
+    private static final AttachmentKey<RequestAttributesMap> ATTACHMENT_KEY =
+            AttachmentKey.create(RequestAttributesMap.class);
+
+    /**
+     * Returns an instance of RequestAttributesMap stored in a given Undertow's HttpServerExchange
+     * object as an attachment. If there had not been such attachment in the exchange, it is created.
+     */
+    public static RequestAttributesMap getOrInitialize(HttpServerExchange exchange) {
+        RequestAttributesMap attributesMap = exchange.getAttachment(ATTACHMENT_KEY);
+        if (attributesMap == null) {
+            attributesMap = new RequestAttributesMap();
+            exchange.putAttachment(ATTACHMENT_KEY, attributesMap);
+        }
+        return attributesMap;
+    }
+}

--- a/src/main/java/org/pac4j/undertow/context/UndertowWebContext.java
+++ b/src/main/java/org/pac4j/undertow/context/UndertowWebContext.java
@@ -20,6 +20,7 @@ import org.pac4j.core.util.CommonHelper;
  *
  * @author Jerome Leleu
  * @author Michael Remond
+ * @author Igor Lobanov
  * @since 1.0.0
  */
 public class UndertowWebContext implements WebContext {

--- a/src/main/java/org/pac4j/undertow/context/UndertowWebContext.java
+++ b/src/main/java/org/pac4j/undertow/context/UndertowWebContext.java
@@ -7,7 +7,6 @@ import io.undertow.server.handlers.form.FormDataParser;
 import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
 
-import java.io.Serializable;
 import java.util.*;
 import java.util.Map.Entry;
 
@@ -15,7 +14,6 @@ import org.pac4j.core.context.Cookie;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.util.CommonHelper;
-import org.pac4j.core.util.JavaSerializationHelper;
 
 /**
  * The webcontext implementation for Undertow.
@@ -25,10 +23,6 @@ import org.pac4j.core.util.JavaSerializationHelper;
  * @since 1.0.0
  */
 public class UndertowWebContext implements WebContext {
-
-    private static final String SPECIFIC_PAC4J_DATA = "_specificPac4jData_";
-
-    private static JavaSerializationHelper JAVA_SERIALIZATION_HELPER = new JavaSerializationHelper();
 
     private final HttpServerExchange exchange;
     private final SessionStore<UndertowWebContext> sessionStore;
@@ -143,11 +137,7 @@ public class UndertowWebContext implements WebContext {
 
     @Override
     public void setRequestAttribute(final String name, final Object value) {
-        String result = null;
-        if (value != null) {
-            result = JAVA_SERIALIZATION_HELPER.serializeToBase64((Serializable) value);
-        }
-        exchange.addPathParam(SPECIFIC_PAC4J_DATA + name, result);
+        RequestAttributesMap.getOrInitialize(exchange).put(name, value);
     }
 
     @Override
@@ -179,28 +169,11 @@ public class UndertowWebContext implements WebContext {
 
     @Override
     public Optional<Object> getRequestAttribute(final String name) {
-        Object value = null;
-        Deque<String> v = exchange.getPathParameters().get(SPECIFIC_PAC4J_DATA + name);
-        if (v != null) {
-            final String serializedValue = v.getFirst();
-            if (serializedValue != null) {
-                value = JAVA_SERIALIZATION_HELPER.deserializeFromBase64(serializedValue);
-            }
-        }
-        return Optional.ofNullable(value);
+        return Optional.ofNullable(RequestAttributesMap.getOrInitialize(exchange).get(name));
     }
 
     @Override
     public boolean isSecure() {
         return exchange.isSecure();
-    }
-
-    public static JavaSerializationHelper getJavaSerializationHelper() {
-        return JAVA_SERIALIZATION_HELPER;
-    }
-
-    public static void setJavaSerializationHelper(final JavaSerializationHelper javaSerializationHelper) {
-        CommonHelper.assertNotNull("javaSerializationHelper", javaSerializationHelper);
-        JAVA_SERIALIZATION_HELPER = javaSerializationHelper;
     }
 }


### PR DESCRIPTION
As discussed in issue #50 it would be more efficient to use object-based attachments map of Undertow's `HttpServerExchange`, instead of string-based path parameters map. This will also reduce the overhead of Java serialization.

Note that `RequestAttributesMap` is not threadsafe, because it is never shared between multiple `HttpServerExchange`, and a given `HttpServerExchange` should never be used in a non-threadsafe way.